### PR TITLE
Fix default location being reset (fixes #26)

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -123,7 +123,6 @@ namespace Yishu {
 
             string homedir = GLib.Environment.get_home_dir ();
             string home = homedir + "/todo.txt";
-            settings.todo_txt_file_path = home;
 
             if (read_file(null)) {
 				window.welcome.hide();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -121,9 +121,6 @@ namespace Yishu {
 				toggle_show_completed();
 			});
 
-            string homedir = GLib.Environment.get_home_dir ();
-            string home = homedir + "/todo.txt";
-
             if (read_file(null)) {
 				window.welcome.hide();
 				window.tree_view.show();

--- a/src/Preferences.vala
+++ b/src/Preferences.vala
@@ -72,6 +72,12 @@ namespace Yishu.Widgets {
             } else if (file_used == other) {
                 list_place.set_active(4);
                 debug ("Set as Other");
+            } else {
+                settings.custom_file_enable = true;
+                list_place.set_active(0);
+                list_place.sensitive = false;
+                label2.sensitive = false;
+                debug ("Set as custom");
             }
 
             list_place.changed.connect (() => {
@@ -126,20 +132,29 @@ namespace Yishu.Widgets {
                 if (settings.custom_file_enable == true) {
                     chooser.sensitive = true;
                     switch_c.active = true;
+                    list_place.sensitive = false;
+                    label2.sensitive = false;
                 } else {
                     chooser.sensitive = false;
                     switch_c.active = false;
+                    list_place.sensitive = true;
+                    label2.sensitive = true;
+                    list_place.set_active(0);
+                    settings.todo_txt_file_path = home;
                 }
             });
 
             if (settings.custom_file_enable == true) {
                 chooser.sensitive = true;
                 switch_c.active = true;
+                list_place.sensitive = false;
+                label2.sensitive = false;
             } else {
                 chooser.sensitive = false;
                 switch_c.active = false;
+                list_place.sensitive = true;
+                label2.sensitive = true;
             }
-
 
             var hbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);
             hbox.pack_start (switch_c, false, true, 0);

--- a/src/Preferences.vala
+++ b/src/Preferences.vala
@@ -55,7 +55,6 @@ namespace Yishu.Widgets {
             string nc = homedir + "/Nextcloud/todo.txt";
             string oc = homedir + "/ownCloud/todo.txt";
             string other = homedir + "/bin/todo.txt/todo.txt";
-            settings.todo_txt_file_path = home;
             string file_used = settings.todo_txt_file_path;
 
             if (file_used == home) {


### PR DESCRIPTION
As mentioned in #26, this fixes the issue where any custom location set by the user is reset every time Yishu starts. While this PR fixes the issue, it makes the **Default Location** field empty.